### PR TITLE
feat: GraphQL type and enum definitions

### DIFF
--- a/.graphqlconfig
+++ b/.graphqlconfig
@@ -1,0 +1,15 @@
+{
+  "name": "GraphQL Schema",
+  "schemaPath": "schema.graphql",
+  "extensions": {
+    "endpoints": {
+      "Default GraphQL Endpoint": {
+        "url": "http://localhost:8080/graphql",
+        "headers": {
+          "user-agent": "JS GraphQL"
+        },
+        "introspect": false
+      }
+    }
+  }
+}

--- a/src/graphql/types/color.graphql
+++ b/src/graphql/types/color.graphql
@@ -1,0 +1,25 @@
+"""
+A set of named colors as described in Material Design
+https://material.io/tools/color
+"""
+enum MaterialColor {
+    red
+    pink
+    purple
+    deepPurple
+    indigo
+    blue
+    lightBlue
+    cyan
+    teal
+    green
+    lightGreen
+    lime
+    yellow
+    amber
+    orange
+    deepOrange
+    brown
+    grey
+    blueGrey
+}

--- a/src/graphql/types/instrument.graphql
+++ b/src/graphql/types/instrument.graphql
@@ -1,0 +1,37 @@
+"""
+Instrument used to build a sequencer track
+"""
+type Instrument {
+    "primary key (UUIDv4)"
+    id: ID!
+
+    label: String!
+
+    group: String!
+
+    "IDs of the samples used in mappings"
+    sampleIDs: [ID!]
+
+    "MIDI mapping — set of maximum 128 entries"
+    mapping: [InstrumentMapping!]!
+
+    "Creation date in ISO 8601 Extended Format"
+    createdAt: String!
+
+    "Update date in ISO 8601 Exteded Format"
+    updatedAt: String!
+}
+
+"""
+Mapping entry for the instrument
+"""
+type InstrumentMapping {
+    "Corresponding MIDI note [0, 127]"
+    note: Int!
+
+    "The associated sample"
+    sampleID: Sample!
+
+    "Detuning of the pitch in cents"
+    detune: Int!
+}

--- a/src/graphql/types/instrument.graphql
+++ b/src/graphql/types/instrument.graphql
@@ -18,7 +18,7 @@ type Instrument {
 
     group: String!
 
-    "Samples used in mappings"
+    "IDs of the samples used in mappings"
     samples: [Sample!]!
 
     "MIDI mapping — set of maximum 128 entries"
@@ -38,7 +38,7 @@ type InstrumentMapping {
     "Corresponding MIDI note [0, 127]"
     note: Int!
 
-    "Associated sample"
+    "The associated sample"
     sample: Sample!
 
     "Detuning of the pitch in cents"

--- a/src/graphql/types/instrument.graphql
+++ b/src/graphql/types/instrument.graphql
@@ -1,3 +1,12 @@
+extend type Query {
+    instrumentList: [Instrument!]!
+}
+
+extend type Mutation {
+    createInstrument(input: InstrumentCreateInput!): InstrumentMutationResponse!
+    deleteInstrument(id: ID!): InstrumentMutationResponse!
+}
+
 """
 Instrument used to build a sequencer track
 """
@@ -9,17 +18,17 @@ type Instrument {
 
     group: String!
 
-    "IDs of the samples used in mappings"
-    sampleIDs: [ID!]
+    "Samples used in mappings"
+    samples: [Sample!]!
 
     "MIDI mapping — set of maximum 128 entries"
     mapping: [InstrumentMapping!]!
 
     "Creation date in ISO 8601 Extended Format"
-    createdAt: String!
+    createdAt: DateTime!
 
     "Update date in ISO 8601 Exteded Format"
-    updatedAt: String!
+    updatedAt: DateTime!
 }
 
 """
@@ -29,9 +38,34 @@ type InstrumentMapping {
     "Corresponding MIDI note [0, 127]"
     note: Int!
 
-    "The associated sample"
+    "Associated sample"
     sample: Sample!
 
     "Detuning of the pitch in cents"
     detune: Int!
+}
+
+input InstrumentCreateInput {
+    label: String!
+
+    group: String
+
+    mapping: [InstrumentMappingCreateInput!]!
+}
+
+input InstrumentMappingCreateInput {
+    note: Int!
+
+    sampleID: String!
+
+    detune: Int!
+}
+
+type InstrumentMutationResponse implements MutationResponse {
+    code: String!
+    success: Boolean!
+    messageTemplate: String!
+    message: String
+    instrument: Instrument
+    error: String
 }

--- a/src/graphql/types/instrument.graphql
+++ b/src/graphql/types/instrument.graphql
@@ -30,7 +30,7 @@ type InstrumentMapping {
     note: Int!
 
     "The associated sample"
-    sampleID: Sample!
+    sample: Sample!
 
     "Detuning of the pitch in cents"
     detune: Int!

--- a/src/graphql/types/processing.graphql
+++ b/src/graphql/types/processing.graphql
@@ -1,0 +1,93 @@
+"""
+Audio processing settings
+"""
+type AudioProcessing {
+    gain: GainProcessing!,
+    filter: FilterProcessing,
+    delay: DelayProcessing,
+    distorsion: DistorsionProcessing
+}
+
+"""
+Gain settings for audio processing
+
+https://webaudio.github.io/web-audio-api/#gainnode
+"""
+type GainProcessing {
+    "Amount of gain"
+    gain: Float!
+}
+
+"""
+Filter settings for audio processing
+
+https://webaudio.github.io/web-audio-api/#biquadfilternode
+"""
+type FilterProcessing {
+    enabled: Boolean!
+
+    "Filter type"
+    type: FilterType!
+
+    "Filter frequency in Hz"
+    frequency: Float!
+
+    "Detuning of the frequency in cents"
+    detune: Int
+
+    "Filter gain"
+    gain: Float!
+
+    "Filter quality factor"
+    q: Float
+}
+
+"""
+Enumeration of filter type for the filter audio processing
+"""
+enum FilterType {
+    lowpass
+    highpass
+    bandpass
+    lowshelf
+    highshelf
+    peaking
+    notch
+    allpass
+}
+
+"""
+Delay settings for audio processing
+
+https://webaudio.github.io/web-audio-api/#DelayNode
+"""
+type DelayProcessing {
+    enabled: Boolean!
+
+    "Amount of delay in s"
+    delayTime: Float!
+}
+
+"""
+Disorsion settings for audio processing
+
+https://webaudio.github.io/web-audio-api/#waveshapernode
+"""
+type DistorsionProcessing {
+    enabled: Boolean!
+
+    "Shaping curve"
+    curve: [Float!]!
+
+    "Type of oversampling"
+    oversample: OversamplingType!
+}
+
+"""
+Enumeration of oversampling types for distorsion audio processing
+"""
+enum OversamplingType {
+    none
+    twoTimes
+    fourTimes
+}

--- a/src/graphql/types/root.graphql
+++ b/src/graphql/types/root.graphql
@@ -23,5 +23,5 @@ interface MutationResponse {
 
 scalar DateTime
 
-# in Apollo server Upload we need to comment out Upload as it's already declared
+# in Apollo server Upload we need to comment out Upload definition as it's already declared
 scalar Upload

--- a/src/graphql/types/root.graphql
+++ b/src/graphql/types/root.graphql
@@ -1,0 +1,27 @@
+type Query {
+    # trick to declare an empty type
+    _: Boolean
+}
+
+type Mutation {
+    # trick to declare an empty type
+    _: Boolean
+}
+
+type Subscription {
+    # trick to declare an empty type
+    _: Boolean
+}
+
+interface MutationResponse {
+    code: String!
+    success: Boolean!
+    messageTemplate: String!
+    message: String
+    error: String
+}
+
+scalar DateTime
+
+# in Apollo server Upload we need to comment out Upload as it's already declared
+scalar Upload

--- a/src/graphql/types/sample.graphql
+++ b/src/graphql/types/sample.graphql
@@ -1,0 +1,18 @@
+type Sample {
+    "primary key (UUIDv4)"
+    id: ID!
+
+    "original filename"
+    filename: String!
+
+    url: String!
+
+    "Mime type"
+    type: String!
+
+    "Sample label"
+    label: String!
+
+    "Group to which the sample should belong"
+    group: String
+}

--- a/src/graphql/types/sample.graphql
+++ b/src/graphql/types/sample.graphql
@@ -1,18 +1,71 @@
+extend type Query {
+    sampleList: [Sample!]!
+}
+
+extend type Mutation {
+    createSample(input: SampleCreateInput!): SampleMutationResponse!
+}
+
+extend type Mutation {
+    updateSample(id: ID!, input: SampleUpdateInput!): SampleMutationResponse!
+}
+
+extend type Mutation {
+    deleteSample(id: ID!): SampleMutationResponse!
+}
+
 type Sample {
-    "primary key (UUIDv4)"
+    """
+    UUID
+    """
     id: ID!
 
-    "original filename"
+    """
+    Sample file name
+    """
     filename: String!
 
+    """
+    Sample url
+    """
     url: String!
 
-    "Mime type"
+    """
+    Mime type
+    """
     type: String!
 
-    "Sample label"
+    """
+    Sample label
+    """
     label: String!
 
-    "Group to which the sample should belong"
+    """
+    Name of the group which the sample belongs to
+    """
     group: String
+
+    createdAt: DateTime!
+
+    updatedAt: DateTime!
+}
+
+input SampleCreateInput {
+    file: Upload!
+    label: String
+    group: String
+}
+
+input SampleUpdateInput {
+    label: String
+    group: String
+}
+
+type SampleMutationResponse implements MutationResponse {
+    code: String!
+    success: Boolean!
+    messageTemplate: String!
+    message: String
+    sample: Sample
+    error: String
 }

--- a/src/graphql/types/session.graphql
+++ b/src/graphql/types/session.graphql
@@ -1,0 +1,37 @@
+type Session {
+    "Primary key (UUIDv4)"
+    id : ID!
+
+    "Username of the user who creates the session"
+    creator: String!
+
+    "Tempo in BPM [20, 200]"
+    tempo: Int!
+
+    "Master gain [0, 1]"
+    masterGain: Int!
+
+    "ID of the active track — its panel is visible"
+    activeTrackID: ID
+
+    "When a track is active, row index (beat) of the currently active cell in the panel"
+    activeCellBeat: Int
+
+    "Track IDs to determine the track order"
+    trackOrder: [ID]!
+
+    "Set of sequencer tracks"
+    tracks: [Track]!
+
+    "Instrument set used by in tracks"
+    instruments: [Instrument]!
+
+    "Sample set played in tracks"
+    samples: [Sample]!
+
+    "Creation date in ISO 8601 Extended Format"
+    createdAt: String!
+
+    "Update date in ISO 8601 Exteded Format"
+    updatedAt: String!
+}

--- a/src/graphql/types/session.graphql
+++ b/src/graphql/types/session.graphql
@@ -52,7 +52,7 @@ input SessionCreateInput {
 input SessionUpdateInput {
     sessionID: ID!
 
-    # add track
+    # instrument for new track
     instrumentID: ID
 }
 

--- a/src/graphql/types/session.graphql
+++ b/src/graphql/types/session.graphql
@@ -1,9 +1,18 @@
+extend type Query {
+    session(id: ID!): Session
+}
+
+extend type Mutation {
+    createSession(input: SessionCreateInput): SessionMutationResponse!
+    updateSession(input: SessionUpdateInput): SessionMutationResponse!
+}
+
 type Session {
     "Primary key (UUIDv4)"
-    id : ID!
+    id: ID!
 
-    "Username of the user who creates the session"
-    creator: String!
+    "ID of the user who creates the session"
+    creatorID: ID!
 
     "Tempo in BPM [20, 200]"
     tempo: Int!
@@ -20,18 +29,38 @@ type Session {
     "Track IDs to determine the track order"
     trackOrder: [ID]!
 
-    "Set of sequencer tracks"
-    tracks: [Track]!
+    "Sequencer tracks"
+    tracks: [Track!]!
 
-    "Instrument set used by in tracks"
-    instruments: [Instrument]!
+    "Instruments used by in tracks"
+    instruments: [Instrument!]!
 
-    "Sample set played in tracks"
-    samples: [Sample]!
+    "Samples played in tracks"
+    samples: [Sample!]!
 
     "Creation date in ISO 8601 Extended Format"
-    createdAt: String!
+    createdAt: DateTime!
 
     "Update date in ISO 8601 Exteded Format"
-    updatedAt: String!
+    updatedAt: DateTime!
+}
+
+input SessionCreateInput {
+    creatorID: ID!
+}
+
+input SessionUpdateInput {
+    sessionID: ID!
+
+    # add track
+    instrumentID: ID
+}
+
+type SessionMutationResponse implements MutationResponse {
+    code: String!
+    success: Boolean!
+    messageTemplate: String!
+    message: String
+    session: Session
+    error: String
 }

--- a/src/graphql/types/track.graphql
+++ b/src/graphql/types/track.graphql
@@ -1,0 +1,45 @@
+"""
+A track part of the session sequencer
+"""
+type Track {
+    "Primary key (UUIDv4)"
+    id: ID!
+
+    "Track label"
+    label: String!
+
+    "Track color"
+    color: MaterialColor!
+
+    "Track note resolution — 1=16th note, 2=8th note, 4=quarter note"
+    noteResolution: Int!
+
+    "Instrument used to build the track"
+    instrument: Instrument!
+
+    "Track mute enabled"
+    muted: Boolean!
+
+    "Track solo enabled"
+    soloed: Boolean!
+
+    "Row of cells (64) to be clock played — row index as beat number"
+    cells: [Cell!]!
+
+    "Audio processing settings"
+    processing: AudioProcessing
+}
+
+"""
+A note to be played
+"""
+type Cell {
+    "Note scheduled or not"
+    scheduled: Boolean!
+
+    "MIDI note [0, 127]"
+    midi: Int!
+
+    "Audio processing settings"
+    processing: AudioProcessing
+}

--- a/src/graphql/types/track.graphql
+++ b/src/graphql/types/track.graphql
@@ -27,7 +27,7 @@ type Track {
     cells: [Cell!]!
 
     "Audio processing settings"
-    processing: AudioProcessing
+    processing: AudioProcessing!
 }
 
 """
@@ -41,5 +41,5 @@ type Cell {
     midi: Int!
 
     "Audio processing settings"
-    processing: AudioProcessing
+    processing: AudioProcessing!
 }


### PR DESCRIPTION
Here's a proposal of type definitions around the Session model

Type definitions:
* Session
* Track
* Cell
* Instrument
* InstrumentMapping
* Sample
* AudioProcessing
* GainProcessing
* FilterProcessing
* DelayProcessing
* DistorsionProcessing
* MaterialColor

Enum definitions:
* FilterType
* OversamplingType

**Notes**:
There's no corresponding type to the Map structure in GraphQL so I've had to adapt the model using arrays.

In the `Instrument` type, the MIDI note for mapping is determined by the index in the mapping array.
This requires to define EVERY notes in the mapping.   
By adding a `note` field in the `InstrumentMapping` type and adding the mapping in the instrument as an array of `InstrumentMapping`, we leave ourselves the choice not to declare certain notes.

At root level I declare a `DateTime` type and a `Upload` file type.
In JS, their definitions  are delegated to _graphql-iso-date_ and _graphql-upload_ libs respectively.